### PR TITLE
feat(Modal): 컴포넌트 고도화 (Portal, 비동기, 중첩)

### DIFF
--- a/components/uis/Modal/Close.tsx
+++ b/components/uis/Modal/Close.tsx
@@ -1,0 +1,36 @@
+import type { ComponentPropsWithoutRef, ElementType } from "react";
+import { useModal } from "./context";
+
+type Props<T extends ElementType> = {
+  as?: T;
+  waitInjectToAs?: (
+    isWaiting: boolean
+  ) => Partial<Omit<ComponentPropsWithoutRef<T>, "onClick">>;
+};
+
+const Close = <T extends ElementType = "button">({
+  as,
+  waitInjectToAs,
+  ...props
+}: Props<T> & Omit<ComponentPropsWithoutRef<T>, keyof Props<T>>) => {
+  const { close, isWaiting, setIsWaiting } = useModal();
+  const Component = as || "button";
+
+  const handleClick = async () => {
+    setIsWaiting(() => true);
+    if (waitInjectToAs) {
+      await props.onClick?.();
+    } else {
+      props.onClick?.();
+    }
+    close();
+    setIsWaiting(() => false);
+  };
+
+  const injectingProps =
+    typeof waitInjectToAs === "function" ? waitInjectToAs(isWaiting) : {};
+
+  return <Component {...props} onClick={handleClick} {...injectingProps} />;
+};
+
+export default Close;

--- a/components/uis/Modal/Open.tsx
+++ b/components/uis/Modal/Open.tsx
@@ -1,0 +1,24 @@
+import type { ComponentPropsWithoutRef, ElementType } from "react";
+import { useModal } from "./context";
+
+type Props<T extends ElementType> = {
+  as?: T;
+  closeAfterOnClick?: boolean;
+};
+
+const Open = <T extends ElementType = "button">({
+  as,
+  ...props
+}: Props<T> & Omit<ComponentPropsWithoutRef<T>, keyof Props<T>>) => {
+  const { open } = useModal();
+  const Component = as || "button";
+
+  const handleClick = async () => {
+    props.onClick?.();
+    open();
+  };
+
+  return <Component {...props} onClick={handleClick} />;
+};
+
+export default Open;

--- a/components/uis/Modal/Portal.tsx
+++ b/components/uis/Modal/Portal.tsx
@@ -1,0 +1,38 @@
+import { useMemo } from "react";
+import { createPortal } from "react-dom";
+
+type Props = {
+  id: string;
+  children: React.ReactNode;
+};
+
+const Portal = ({ id, children }: Props) => {
+  const portal = useMemo<HTMLElement>(() => {
+    const portalEl = document.getElementById(id);
+
+    if (portalEl) {
+      return portalEl;
+    }
+
+    const newPortalEl = document.createElement("div");
+    newPortalEl.id = id;
+    newPortalEl.style.left = "0";
+    newPortalEl.style.right = "0";
+    newPortalEl.style.top = "0";
+    newPortalEl.style.bottom = "0";
+    newPortalEl.style.zIndex = "9999";
+    newPortalEl.style.position = "fixed";
+    newPortalEl.style.display = "flex";
+    newPortalEl.style.flexDirection = "column";
+    newPortalEl.style.justifyContent = "center";
+    newPortalEl.style.alignItems = "center";
+
+    document.body.appendChild(newPortalEl);
+
+    return newPortalEl;
+  }, [id]);
+
+  return createPortal(children, portal);
+};
+
+export default Portal;

--- a/components/uis/Modal/context.ts
+++ b/components/uis/Modal/context.ts
@@ -1,0 +1,11 @@
+import { useContext, createContext } from "react";
+
+const Context = createContext({
+  open: (() => {}) as () => Promise<void>,
+  close: (() => {}) as () => Promise<void>,
+  isWaiting: false,
+  setIsWaiting: (() => {}) as React.Dispatch<React.SetStateAction<boolean>>,
+});
+export default Context;
+
+export const useModal = () => useContext(Context);

--- a/components/uis/Modal/context.ts
+++ b/components/uis/Modal/context.ts
@@ -1,11 +1,13 @@
 import { useContext, createContext } from "react";
 
-const Context = createContext({
-  open: (() => {}) as () => Promise<void>,
-  close: (() => {}) as () => Promise<void>,
-  isWaiting: false,
-  setIsWaiting: (() => {}) as React.Dispatch<React.SetStateAction<boolean>>,
-});
+type InitialState = {
+  open: () => Promise<void>,
+  close: () => Promise<void>,
+  isWaiting: boolean,
+  setIsWaiting: React.Dispatch<React.SetStateAction<boolean>>,
+}
+
+const Context = createContext({} as InitialState)
 export default Context;
 
 export const useModal = () => useContext(Context);

--- a/components/uis/Modal/index.tsx
+++ b/components/uis/Modal/index.tsx
@@ -6,6 +6,8 @@ import Context from "./context";
 import Open from "./Open";
 import Portal from "./Portal";
 
+const DEFAULT_PORTAL_ID_PREFIX = "modal-portal";
+
 type UseDisclosure = typeof useDisclosure;
 
 type Props = {
@@ -25,21 +27,26 @@ type Props = {
 };
 
 const Modal = ({
-  portalId = "modal-portal",
+  portalId,
   initialIsOpen = false,
   trigger,
   onOpen,
   onClose,
   modal,
 }: Props) => {
-  const portalIdMemoized = useMemo(() => portalId, []);
+  const memoizedPortalId = useMemo(() => {
+    return typeof portalId === "string" && portalId !== DEFAULT_PORTAL_ID_PREFIX
+      ? portalId
+      : `${DEFAULT_PORTAL_ID_PREFIX}-${new Date().getTime()}`;
+  }, []);
+
   const [isWaiting, setIsWaiting] = useState(false);
   const { isOpen, close, open } = useDisclosure({
     initialState: initialIsOpen,
     onOpen,
     onClose: async () => {
       await onClose?.();
-      document.getElementById(portalIdMemoized)?.remove();
+      document.getElementById(memoizedPortalId)?.remove();
     },
   });
 
@@ -47,7 +54,7 @@ const Modal = ({
     <Context.Provider value={{ open, close, isWaiting, setIsWaiting }}>
       {typeof trigger === "function" ? trigger({ open }) : trigger}
       {isOpen ? (
-        <Portal id={portalIdMemoized}>
+        <Portal id={memoizedPortalId}>
           {typeof modal === "function" ? modal({ close, isWaiting }) : modal}
         </Portal>
       ) : null}

--- a/components/uis/Modal/index.tsx
+++ b/components/uis/Modal/index.tsx
@@ -1,61 +1,63 @@
-import type { ReactElement } from "react";
-import { useContext, createContext } from "react";
+import type { ReactElement, ReactNode } from "react";
+import { useMemo, useState } from "react";
 import { useDisclosure } from "~/hooks/commons";
+import Close from "./Close";
+import Context from "./context";
+import Open from "./Open";
+import Portal from "./Portal";
 
-const Context = createContext({
-  close: (() => {}) as () => Promise<void>,
-});
-
-export const useModal = () => useContext(Context);
+type UseDisclosure = typeof useDisclosure;
 
 type Props = {
-  trigger: (args: { open: () => void }) => ReactElement;
+  portalId?: string;
+  trigger:
+    | ReactNode
+    | ((args: { open: ReturnType<UseDisclosure>["open"] }) => ReactElement);
   modal:
-    | React.ReactNode
-    | ((args: { close: () => Promise<void> }) => ReactElement);
-  initialState?: Parameters<typeof useDisclosure>[0]["initialState"];
-  onOpen?: Parameters<typeof useDisclosure>[0]["onOpen"];
-  onClose?: Parameters<typeof useDisclosure>[0]["onClose"];
+    | ReactNode
+    | ((args: {
+        close: ReturnType<UseDisclosure>["close"];
+        isWaiting: boolean;
+      }) => ReactElement);
+  initialIsOpen?: Parameters<UseDisclosure>[0]["initialState"];
+  onOpen?: Parameters<UseDisclosure>[0]["onOpen"];
+  onClose?: Parameters<UseDisclosure>[0]["onClose"];
 };
 
 const Modal = ({
-  initialState = false,
+  portalId = "modal-portal",
+  initialIsOpen = false,
   trigger,
   onOpen,
   onClose,
   modal,
 }: Props) => {
+  const portalIdMemoized = useMemo(() => portalId, []);
+  const [isWaiting, setIsWaiting] = useState(false);
   const { isOpen, close, open } = useDisclosure({
-    initialState,
+    initialState: initialIsOpen,
     onOpen,
-    onClose,
+    onClose: async () => {
+      await onClose?.();
+      document.getElementById(portalIdMemoized)?.remove();
+    },
   });
 
-  const modalOpened = typeof modal === "function" ? modal({ close }) : modal;
-
   return (
-    <Context.Provider value={{ close }}>
-      {trigger({ open })}
-      {isOpen ? modalOpened : null}
+    <Context.Provider value={{ open, close, isWaiting, setIsWaiting }}>
+      {typeof trigger === "function" ? trigger({ open }) : trigger}
+      {isOpen ? (
+        <Portal id={portalIdMemoized}>
+          {typeof modal === "function" ? modal({ close, isWaiting }) : modal}
+        </Portal>
+      ) : null}
     </Context.Provider>
   );
 };
 
-type CloseProps<T extends React.ElementType> = {
-  as?: T;
-};
+export default Modal;
 
-const Close = <T extends React.ElementType = "button">({
-  as,
-  ...props
-}: CloseProps<T> &
-  Omit<React.ComponentPropsWithoutRef<T>, keyof CloseProps<T>>) => {
-  const { close } = useModal();
-  const Component = as || "button";
-
-  return <Component onClick={close} {...props} />;
-};
-
+Modal.Open = Open;
 Modal.Close = Close;
 
-export default Modal;
+export { useModal } from "./context";

--- a/pages/test/modal/index.tsx
+++ b/pages/test/modal/index.tsx
@@ -1,0 +1,171 @@
+import type { ComponentProps } from "react";
+import React from "react";
+import { css } from "@emotion/react";
+import styled from "@emotion/styled";
+import { Layout, Modal, Spacer } from "~/components/uis";
+
+const getAsyncText = async (text = "비동기처리 끝", ms = 1000) => {
+  return new Promise((resolve) => {
+    setTimeout(() => {
+      resolve(text);
+    }, ms);
+  });
+};
+
+const ModalTestPage = () => {
+  const handleConfirm = async () => {
+    const awaitedText = await getAsyncText();
+    console.log(awaitedText);
+  };
+
+  return (
+    <Layout>
+      <Spacer type="horizontal" gap={16}>
+        <Modal
+          trigger={
+            <Modal.Open
+              as={LoadingButton}
+              onClick={() => console.log("모달 1 열기")}
+            >
+              모달 1 열기 (비동기 처리 기다리고 닫기)
+            </Modal.Open>
+          }
+          modal={
+            <S.Modal>
+              <Spacer type="vertical" gap={12}>
+                <h1>비동기처리를 기다리고 닫기</h1>
+                <Modal.Close
+                  as={LoadingButton}
+                  waitInjectToAs={(loading) => ({ loading, disabled: loading })}
+                  onClick={handleConfirm}
+                >
+                  Modal.Close.waitOnClick: true (DEFAULT)
+                </Modal.Close>
+              </Spacer>
+            </S.Modal>
+          }
+        />
+        <Modal
+          trigger={({ open }) => (
+            <LoadingButton onClick={open}>
+              모달 2 열기 (비동기 처리 기다리지 않고 닫기)
+            </LoadingButton>
+          )}
+          modal={
+            <S.Modal>
+              <Spacer type="vertical" gap={12}>
+                <h1>비동기처리 전이라도 일단 닫기</h1>
+                <Modal.Close as={LoadingButton} onClick={handleConfirm}>
+                  Modal.Close.waitOnClick: false
+                </Modal.Close>
+                <Modal
+                  portalId="depth-modal"
+                  trigger={
+                    <Modal.Open
+                      as={LoadingButton}
+                      onClick={() => console.log("모달 1 열기")}
+                    >
+                      모달 1 열기 (비동기 처리 기다리고 닫기)
+                    </Modal.Open>
+                  }
+                  modal={
+                    <S.Modal>
+                      <Spacer type="vertical" gap={12}>
+                        <h1>비동기처리를 기다리고 닫기</h1>
+                        <Modal.Close
+                          as={LoadingButton}
+                          waitInjectToAs={(loading) => ({
+                            loading,
+                            disabled: loading,
+                          })}
+                          onClick={handleConfirm}
+                        >
+                          Modal.Close.waitOnClick: true (DEFAULT)
+                        </Modal.Close>
+                      </Spacer>
+                    </S.Modal>
+                  }
+                />
+              </Spacer>
+            </S.Modal>
+          }
+        />
+      </Spacer>
+    </Layout>
+  );
+};
+
+export default ModalTestPage;
+
+const LoadingButton = ({
+  loading = false,
+  children,
+  ...props
+}: ComponentProps<typeof S.Button> & { loading?: boolean }) => {
+  return (
+    <S.Button {...props}>
+      <Spacer gap={8} align="center">
+        {loading && <S.Spinner />}
+        {children}
+      </Spacer>
+    </S.Button>
+  );
+};
+
+const S = {
+  Button: styled.button`
+    ${({ theme }) => css`
+      display: flex;
+      justify-content: center;
+      align-items: center;
+      color: white;
+      background-color: ${theme.colors.blue0500};
+      height: 40px;
+      padding: 18px;
+      border-radius: 16px;
+      border: none;
+      cursor: pointer;
+
+      &:hover {
+        opacity: 0.85;
+      }
+
+      &:disabled {
+        cursor: not-allowed;
+        filter: contrast(0.8);
+      }
+
+      transition: 0.2s opacity;
+    `}
+  `,
+
+  Modal: styled.div`
+    width: 100%;
+    max-width: 500px;
+    margin: 16px;
+    padding: 16px;
+    background-color: white;
+    box-shadow: 0px 16px 32px -16px rgba(0, 0, 0, 0.2);
+    border-radius: 16px;
+  `,
+
+  Spinner: styled.div`
+    ${({ theme }) => css`
+      border: 3px solid ${theme.colors.blue0100};
+      border-top: 3px solid ${theme.colors.blue0200};
+      border-radius: 50%;
+      width: 30px;
+      height: 30px;
+      animation: spin 1s linear infinite;
+
+      @keyframes spin {
+        0% {
+          transform: rotate(0deg);
+        }
+        100% {
+          transform: rotate(360deg);
+        }
+      }
+    `}
+  `,
+};

--- a/pages/test/modal/index.tsx
+++ b/pages/test/modal/index.tsx
@@ -59,7 +59,6 @@ const ModalTestPage = () => {
                   Modal.Close.waitOnClick: false
                 </Modal.Close>
                 <Modal
-                  portalId="depth-modal"
                   trigger={
                     <Modal.Open
                       as={LoadingButton}


### PR DESCRIPTION
ISSUES CLOSED: #83

# Modal 개선하기

## 1. 비동기 처리
Modal을 닫을 때 비동기 처리를 기다렸다가 닫을 지 바로 닫을 지 Modal.Close로 설정할 수 있어요.
![Aug-10-2022 22-41-48](https://user-images.githubusercontent.com/61593290/183916381-ce56c80e-6341-460e-a2d2-38ec6dbe4581.gif)

## 2. 비동기 대기 상태를 as에 주입
Modal.Close의 as에 waitInject로 모달의 액션을 연결해 기다리고 있는지를 주입할 수 있어요. 기다리고 있는지를 주입해 두번 클릭되지 않도록 disabled처리하고, 유저가 기다릴 수 있게 로딩을 띄울 수도 있어요. as컴포넌트의 prop에 맞게 변형해주면 되요. (타이핑 완료)
![chrome-capture-2022-7-10 (1)](https://user-images.githubusercontent.com/61593290/183914161-5e38f7e1-ef76-4be3-b927-7627bceaeb24.gif)

## 3. Portal로 부모 엘리멘트의 영향에서 벗어나기
Portal로 Modal을 보내 부모의 상태는 영향을 받되, 실제 document상에는 외부에 위치시켜 스타일 등을 격리 시켜요.
![Aug-10-2022 22-44-19](https://user-images.githubusercontent.com/61593290/183916959-f649953f-9180-41b3-bf71-615bffd22986.gif)

## 4. 중첩된 Modal 처리
portalId를 현재 시간으로 생성해 중첩된 portal을 구분해 생성하고 닫아요
![chrome-capture-2022-7-10 (2)](https://user-images.githubusercontent.com/61593290/183915003-2d449aa4-f569-440c-9f9c-47c0f90b2db5.gif)

# Modal의 사용법
기본적으로 interface를 구성할 때 Portal외의 style은 외부에서 담당하도록 처리했어요. 따라서  모달과 버튼에 들어갈 내용과 스타일은 모두 커스텀할 수 있어요.

```typescript
const getAsyncText = async (text = "비동기처리 끝", ms = 1000) => {
  return new Promise((resolve) => {
    setTimeout(() => {
      resolve(text);
    }, ms);
  });
};

const ModalTestPage = () => {
  const handleConfirm = async () => {
    const awaitedText = await getAsyncText();
    console.log(awaitedText);
  };

  return (
    <Layout>
      <Spacer type="horizontal" gap={16}>
        <Modal
          trigger={
            <Modal.Open
              as={LoadingButton}
              onClick={() => console.log("모달 1 열기")}
            >
              모달 1 열기 (비동기 처리 기다리고 닫기)
            </Modal.Open>
          }
          modal={
            <S.Modal>
              <Spacer type="vertical" gap={12}>
                <h1>비동기처리를 기다리고 닫기</h1>
                <Modal.Close
                  as={LoadingButton}
                  waitInjectToAs={(loading) => ({ loading, disabled: loading })}
                  onClick={handleConfirm}
                >
                  Modal.Close.waitOnClick: true (DEFAULT)
                </Modal.Close>
              </Spacer>
            </S.Modal>
          }
        />
        <Modal
          trigger={({ open }) => (
            <LoadingButton onClick={open}>
              모달 2 열기 (비동기 처리 기다리지 않고 닫기)
            </LoadingButton>
          )}
          modal={
            <S.Modal>
              <Spacer type="vertical" gap={12}>
                <h1>비동기처리 전이라도 일단 닫기</h1>
                <Modal.Close as={LoadingButton} onClick={handleConfirm}>
                  Modal.Close.waitOnClick: false
                </Modal.Close>
              </Spacer>
            </S.Modal>
          }
        />
      </Spacer>
    </Layout>
  );
};

export default ModalTestPage;

const LoadingButton = ({
  loading = false,
  children,
  ...props
}: ComponentProps<typeof S.Button> & { loading?: boolean }) => {
  return (
    <S.Button {...props}>
      <Spacer gap={8} align="center">
        {loading && <S.Spinner />}
        {children}
      </Spacer>
    </S.Button>
  );
};

```
