### PR TITLE
feat(Routing): 방 생성 후 이동 / 뒤로 가기 라우팅 코드 추가

### DIFF
--- a/components/domains/KakaoLoginButton/index.tsx
+++ b/components/domains/KakaoLoginButton/index.tsx
@@ -28,6 +28,8 @@ const KakaoLoginButton = ({
     width: "100%",
     height: "51px",
     background: "url('images/kakao_login_large_wide.png')",
+    backgroundRepeat: "no-repeat",
+    backgroundSize: "auto",
     cursor: "pointer",
     border: "none",
   };

--- a/components/uis/TopBar/TopBarIconButton.tsx
+++ b/components/uis/TopBar/TopBarIconButton.tsx
@@ -1,5 +1,6 @@
 import React from "react";
 import Image from "next/image";
+import { useRouter } from "next/router";
 import styled from "@emotion/styled";
 
 interface TopBarIconButtonProps {
@@ -12,8 +13,13 @@ const TopBarIconButton = ({
   alt,
   onClick,
 }: TopBarIconButtonProps) => {
+  const router = useRouter();
+  const backButton = () => {
+    router.back();
+  };
+
   return (
-    <StyledIconWrapper onClick={onClick}>
+    <StyledIconWrapper onClick={onClick ?? backButton}>
       <Image
         src={`/images/${iconName}.svg`}
         alt={alt ?? "icon"}

--- a/features/auth/redirected/index.ts
+++ b/features/auth/redirected/index.ts
@@ -31,7 +31,7 @@ export const useAuthRedirected = () => {
     {
       onSuccess: () => {
         refetchMemberInfo();
-        router.replace("/");
+        router.replace("/rooms/create");
       },
     }
   );

--- a/pages/index.tsx
+++ b/pages/index.tsx
@@ -57,6 +57,9 @@ const S = {
     letter-spacing: -0.478073px;
     display: flex;
     align-items: center;
+    background-color: black;
+    border: none;
+    cursor: pointer;
   `,
   InviteContainer: styled.div`
     display: flex;

--- a/pages/rooms/create/mood/index.tsx
+++ b/pages/rooms/create/mood/index.tsx
@@ -45,11 +45,7 @@ const RoomCreateMoodPage: NextPage = () => {
     })
       .then((room) => {
         const { roomId } = room;
-        router.push(
-          `/rooms/${roomId}`,
-          { query: { roomId } },
-          { shallow: true }
-        );
+        router.push(`/rooms/${roomId}/`);
       })
       .catch((reason: any) => {
         // TODO: 실패 이유 팝업 핸들링


### PR DESCRIPTION
ISSUES CLOSED: #96

### Issue Number

close: #96

### 작업 내역

> 구현 내용 및 작업 했던 내역

- [x] 방 생성 후 이동
- [x] 뒤로 가기 라우팅 코드 추가
- [x] 방 생성 시 `isHost=true` 추가
- [x] 카카오 로그인 백그라운드 반복되는 현상 수정

### Checklist

> PR 등록 전 확인할 점

- [x] PR 제목은 포맷과 내용 둘 다 알맞게 작성되었는가 (e.g., `feat(user): add login page`)
- [x] assignee가 본인으로 되어있고, label은 PR 주제에 맞게 추가했는가
- [x] description에 PR에 대해 구체적으로 설명했는가
