### PR TITLE
feat(web-socket): 웹소켓 코어 로직 구현

### DIFF
--- a/consts/index.ts
+++ b/consts/index.ts
@@ -1,0 +1,1 @@
+export const isBrowser = typeof window !== "undefined";

--- a/consts/web-socket/index.ts
+++ b/consts/web-socket/index.ts
@@ -1,0 +1,9 @@
+export const SOCKET_RES_TYPE = {
+  emoji: "EMOJI",
+  playlistItemRequest: "PLAYLIST_ITEM_REQUEST",
+  playlistItemAdd: "PLAYLIST_ITEM_ADD",
+  playlistItemRequestDecline: "PLAYLIST_ITEM_REQUEST_DECLINE",
+  playlistItemRemove: "PLAYLIST_ITEM_REMOVE",
+  playlistItemChangeOrder: "PLAYLIST_ITEM_CHANGE_ORDER",
+} as const;
+export type SocketResType = keyof typeof SOCKET_RES_TYPE;

--- a/contexts/Socket/index.tsx
+++ b/contexts/Socket/index.tsx
@@ -1,0 +1,155 @@
+/* eslint-disable no-console */
+import { createContext, useContext, useEffect } from "react";
+import type { IMessage, IStompSocket } from "@stomp/stompjs";
+import { Client } from "@stomp/stompjs";
+import { useRecoilState } from "recoil";
+import SockJS from "sockjs-client";
+import { isBrowser } from "~/consts";
+import { emojiAtomState } from "~/store/emoji";
+import { playlistAtomState } from "~/store/playlist";
+import { userQueueAtomState } from "~/store/user";
+import type { Emoji } from "~/types/emoji";
+import type { Playlist } from "~/types/playlist";
+import type { StompCallbackMessage } from "~/types/webSocket";
+
+interface InitialState {
+  socket: Client;
+}
+const SocketContext = createContext({} as InitialState);
+
+interface Props {
+  children: React.ReactNode;
+}
+
+const STOMP_SERVER_URL = process.env
+  .NEXT_PUBLIC_SERVER_STOMP_END_POINT as string;
+const ROOM_ID = 2; // XXX: For test
+const tokenKey = process.env.NEXT_PUBLIC_LOCAL_TOKEN_KEY as string;
+const localStorageToken: string | null = isBrowser
+  ? JSON.parse(localStorage.getItem(tokenKey) as string)
+  : null;
+
+const socket = new Client();
+socket.configure({
+  brokerURL: STOMP_SERVER_URL,
+  connectHeaders: {
+    Authorization: `Bearer ${localStorageToken}`,
+    "Content-Type": "application/json",
+  },
+  debug: (str) => {
+    console.debug(new Date(), str);
+  },
+  reconnectDelay: 5000,
+  heartbeatIncoming: 4000,
+  heartbeatOutgoing: 4000,
+});
+
+// Fallback code
+if (typeof WebSocket !== "function") {
+  socket.webSocketFactory = () => {
+    return new SockJS(STOMP_SERVER_URL) as IStompSocket;
+  };
+}
+
+const SocketProvider = ({ children }: Props) => {
+  const [, setUserQueue] = useRecoilState(userQueueAtomState);
+  const [, setEmoji] = useRecoilState(emojiAtomState);
+  const [, setPlaylist] = useRecoilState(playlistAtomState);
+  const subscribe = () => {
+    socket.subscribe(
+      `/topic/v1/rooms/${ROOM_ID}`,
+      (message: IMessage) => {
+        if (message.body) {
+          const newMessage: StompCallbackMessage = JSON.parse(message.body);
+          // 메시지 타입에 따라서 상태 다르게 적용하기
+          switch (newMessage.type) {
+            case "ERROR":
+              console.error(newMessage.code, newMessage.message);
+              break;
+            case "EMOJI":
+              setEmoji(newMessage.data as Emoji);
+              break;
+            case "PLAYLIST_ITEM_ADD":
+              setPlaylist((_playlist: Playlist[]) => [
+                ..._playlist,
+                newMessage.data as Playlist,
+              ]);
+              break;
+            default:
+              console.error("등록되지 않은 메시지 타입입니다.");
+              break;
+          }
+        } else {
+          console.error("got empty message");
+        }
+      },
+      { Authorization: `Bearer ${localStorageToken}` }
+    );
+    socket.subscribe(
+      "/user/queue",
+      (message: IMessage) => {
+        if (message.body) {
+          const newMessage: StompCallbackMessage = JSON.parse(message.body);
+          // 메시지 타입에 따라서 상태 다르게 적용하기
+          switch (newMessage.type) {
+            case "ERROR":
+              console.error(newMessage.code, newMessage.message);
+              break;
+            case "PLAYLIST_ITEM_REQUEST":
+              setUserQueue((_userQueue: Playlist[]) => [
+                ..._userQueue,
+                newMessage.data as Playlist,
+              ]);
+              break;
+            default:
+              console.error("등록되지 않은 메시지 타입입니다.");
+              break;
+          }
+        } else {
+          console.error("got empty message");
+        }
+      },
+      { Authorization: `Bearer ${localStorageToken}` }
+    );
+  };
+
+  const connect = () => {
+    socket.onConnect = () => {
+      console.log("connect!");
+      subscribe();
+    };
+
+    socket.onStompError = (frame) => {
+      console.debug(`Broker reported error: ${frame.headers.message}`);
+      console.debug(`Additional details: ${frame.body}`);
+    };
+
+    socket.activate();
+  };
+
+  const disConnect = () => {
+    if (socket.connected) {
+      socket.deactivate();
+    }
+  };
+
+  useEffect(() => {
+    connect();
+
+    return () => disConnect();
+  }, []);
+
+  return (
+    <SocketContext.Provider
+      value={{
+        socket,
+      }}
+    >
+      {children}
+    </SocketContext.Provider>
+  );
+};
+
+export const useSocket = () => useContext(SocketContext);
+
+export default SocketProvider;

--- a/hooks/webSocket/index.ts
+++ b/hooks/webSocket/index.ts
@@ -1,7 +1,7 @@
 import type { IPublishParams } from "@stomp/stompjs";
 import { useSocket } from "~/contexts/Socket";
 import type { Emoji } from "~/types/emoji";
-import type { Playlist } from "~/types/playlist";
+import type { PlaylistItem } from "~/types/playlist";
 
 // 웹소켓 베이스 use hook
 export const useWebSocketPublish = (
@@ -30,7 +30,7 @@ export const useEmoji = (roomId: number, body: Omit<Emoji, "senderId">) => {
 
 export const useAddPlaylistItemRequest = (
   roomId: number,
-  body: Omit<Playlist, "playlistItemId">
+  body: Omit<PlaylistItem, "playlistItemId">
 ) => {
   return useWebSocketPublish(`/app/v1/rooms/${roomId}/add-playlist-item`, {
     body: JSON.stringify(body),

--- a/hooks/webSocket/index.ts
+++ b/hooks/webSocket/index.ts
@@ -1,0 +1,38 @@
+import type { IPublishParams } from "@stomp/stompjs";
+import { useSocket } from "~/contexts/Socket";
+import type { Emoji } from "~/types/emoji";
+import type { Playlist } from "~/types/playlist";
+
+// 웹소켓 베이스 use hook
+export const useWebSocketPublish = (
+  url: string,
+  params: Omit<IPublishParams, "destination">
+) => {
+  const { socket } = useSocket();
+  const publish = async () => {
+    if (socket.connected) {
+      await socket.publish({
+        ...params,
+        destination: url,
+        skipContentLengthHeader: true,
+      });
+    }
+  };
+
+  return { publish };
+};
+
+export const useEmoji = (roomId: number, body: Omit<Emoji, "senderId">) => {
+  return useWebSocketPublish(`/app/v1/rooms/${roomId}/send-emoji`, {
+    body: JSON.stringify(body),
+  });
+};
+
+export const useAddPlaylistItemRequest = (
+  roomId: number,
+  body: Omit<Playlist, "playlistItemId">
+) => {
+  return useWebSocketPublish(`/app/v1/rooms/${roomId}/add-playlist-item`, {
+    body: JSON.stringify(body),
+  });
+};

--- a/pages/_app.tsx
+++ b/pages/_app.tsx
@@ -8,6 +8,7 @@ import { ReactQueryDevtools } from "react-query/devtools";
 import { RecoilRoot } from "recoil";
 import { Layout } from "~/components/uis";
 import { MemberInfo } from "~/contexts";
+import SocketProvider from "~/contexts/Socket";
 import { emotionTheme } from "~/theme";
 
 const queryClient = new QueryClient();
@@ -21,7 +22,9 @@ function MyApp({ Component, pageProps }: AppProps) {
           <QueryClientProvider client={queryClient}>
             <ThemeProvider theme={emotionTheme}>
               <MemberInfo.Provider>
-                <Component {...pageProps} />
+                <SocketProvider>
+                  <Component {...pageProps} />
+                </SocketProvider>
               </MemberInfo.Provider>
             </ThemeProvider>
             <ReactQueryDevtools initialIsOpen={false} position="bottom-right" />

--- a/pages/socket-test/index.tsx
+++ b/pages/socket-test/index.tsx
@@ -4,14 +4,13 @@ import type { NextPage } from "next";
 import { useRecoilValue } from "recoil";
 import { useEmoji, useAddPlaylistItemRequest } from "~/hooks/webSocket";
 import { emojiAtomState } from "~/store/emoji";
-import { playlistAtomState } from "~/store/playlist";
-import { userQueueAtomState } from "~/store/user";
+import { playlistAtomState, proposedPlaylistAtomState } from "~/store/playlist";
 
-const ROOM_ID = 2; // XXX: for test. room 정보 api 연동되면 삭제
+const ROOM_ID = 1; // XXX: for test. room 정보 api 연동되면 삭제
 const SocketTestPage: NextPage = () => {
   const emoji = useRecoilValue(emojiAtomState);
   const playlist = useRecoilValue(playlistAtomState);
-  const userQueue = useRecoilValue(userQueueAtomState);
+  const proposedPlaylist = useRecoilValue(proposedPlaylistAtomState);
   const { publish: publishEmoji } = useEmoji(ROOM_ID, {
     emojiType: "HEART",
     intensity: 100,
@@ -27,8 +26,8 @@ const SocketTestPage: NextPage = () => {
   useEffect(() => {
     console.log("emoji", emoji);
     console.log("playlist", playlist);
-    console.log("userQueue", userQueue);
-  }, [emoji, playlist, userQueue]);
+    console.log("userQueue", proposedPlaylist);
+  }, [emoji, playlist, proposedPlaylist]);
 
   return (
     <div>

--- a/store/emoji/index.ts
+++ b/store/emoji/index.ts
@@ -1,0 +1,7 @@
+import { atom } from "recoil";
+import type { Emoji } from "~/types/emoji";
+
+export const emojiAtomState = atom<Emoji>({
+  key: "emoji",
+  default: undefined,
+});

--- a/store/playlist/index.ts
+++ b/store/playlist/index.ts
@@ -1,13 +1,13 @@
 import { atom } from "recoil";
 import type { Playlist } from "~/types/playlist";
-import type { Room } from "~/types/rooms";
 
-export const roomAtomState = atom<Room>({
-  key: "socket-room", // 현재 이미 사용 중인 room이 있어 중복 방지를 위해 키값 적용
-  default: undefined,
+export const playlistAtomState = atom<Playlist>({
+  key: "playlist",
+  default: [],
 });
 
-export const playlistAtomState = atom<Playlist[]>({
-  key: "playlist",
+// 방장만 확인 가능: 신청된 곡 목록
+export const proposedPlaylistAtomState = atom<Playlist>({
+  key: "proposed-playlist",
   default: [],
 });

--- a/store/playlist/index.ts
+++ b/store/playlist/index.ts
@@ -1,0 +1,13 @@
+import { atom } from "recoil";
+import type { Playlist } from "~/types/playlist";
+import type { Room } from "~/types/rooms";
+
+export const roomAtomState = atom<Room>({
+  key: "socket-room", // 현재 이미 사용 중인 room이 있어 중복 방지를 위해 키값 적용
+  default: undefined,
+});
+
+export const playlistAtomState = atom<Playlist[]>({
+  key: "playlist",
+  default: [],
+});

--- a/store/user/index.ts
+++ b/store/user/index.ts
@@ -1,0 +1,7 @@
+import { atom } from "recoil";
+import type { Playlist } from "~/types/playlist";
+
+export const userQueueAtomState = atom<Playlist[]>({
+  key: "userQueue",
+  default: undefined,
+});

--- a/store/user/index.ts
+++ b/store/user/index.ts
@@ -1,7 +1,7 @@
 import { atom } from "recoil";
 import type { Playlist } from "~/types/playlist";
 
-export const userQueueAtomState = atom<Playlist[]>({
+export const userQueueAtomState = atom<Playlist>({
   key: "userQueue",
   default: undefined,
 });

--- a/types/emoji/index.ts
+++ b/types/emoji/index.ts
@@ -1,0 +1,5 @@
+export interface Emoji {
+  emojiType: "HEART" | "MIRROR_BALL" | "BOOK";
+  intensity: number;
+  senderId: number;
+}

--- a/types/playlist/index.ts
+++ b/types/playlist/index.ts
@@ -1,4 +1,4 @@
-export interface Playlist {
+export interface PlaylistItem {
   playlistItemId: number;
   playlistId: number;
   videoId: string;
@@ -7,3 +7,5 @@ export interface Playlist {
   duration: string;
   dominantColor: string;
 }
+
+export type Playlist = PlaylistItem[];

--- a/types/playlist/index.ts
+++ b/types/playlist/index.ts
@@ -1,0 +1,9 @@
+export interface Playlist {
+  playlistItemId: number;
+  playlistId: number;
+  videoId: string;
+  title: string;
+  thumbnail: string;
+  duration: string;
+  dominantColor: string;
+}

--- a/types/webSocket/index.ts
+++ b/types/webSocket/index.ts
@@ -1,0 +1,20 @@
+import type { Emoji } from "~/types/emoji";
+import type { Playlist } from "~/types/playlist";
+
+export const SOCKET_RES_TYPE = {
+  error: "ERROR",
+  emoji: "EMOJI",
+  playlistItemRequest: "PLAYLIST_ITEM_REQUEST",
+  playlistItemAdd: "PLAYLIST_ITEM_ADD",
+  playlistItemRequestDecline: "PLAYLIST_ITEM_REQUEST_DECLINE",
+  playlistItemRemove: "PLAYLIST_ITEM_REMOVE",
+  playlistItemChangeOrder: "PLAYLIST_ITEM_CHANGE_ORDER",
+} as const;
+type SocketResType = keyof typeof SOCKET_RES_TYPE;
+
+export interface StompCallbackMessage {
+  type: typeof SOCKET_RES_TYPE[SocketResType];
+  code: string;
+  message: string;
+  data: Playlist | Emoji;
+}

--- a/types/webSocket/index.ts
+++ b/types/webSocket/index.ts
@@ -1,5 +1,5 @@
 import type { Emoji } from "~/types/emoji";
-import type { Playlist } from "~/types/playlist";
+import type { PlaylistItem } from "~/types/playlist";
 
 export const SOCKET_RES_TYPE = {
   error: "ERROR",
@@ -10,11 +10,26 @@ export const SOCKET_RES_TYPE = {
   playlistItemRemove: "PLAYLIST_ITEM_REMOVE",
   playlistItemChangeOrder: "PLAYLIST_ITEM_CHANGE_ORDER",
 } as const;
-type SocketResType = keyof typeof SOCKET_RES_TYPE;
+type SocketResType = typeof SOCKET_RES_TYPE;
 
-export interface StompCallbackMessage {
-  type: typeof SOCKET_RES_TYPE[SocketResType];
-  code: string;
-  message: string;
-  data: Playlist | Emoji;
-}
+export type StompCallbackMessage =
+  | {
+      type: SocketResType["error"];
+      code: string;
+      message: string;
+      data: null;
+    }
+  | {
+      type: SocketResType["emoji"];
+      code: string;
+      message: string;
+      data: Emoji;
+    }
+  | {
+      type:
+        | SocketResType["playlistItemRequest"]
+        | SocketResType["playlistItemAdd"];
+      code: string;
+      message: string;
+      data: PlaylistItem;
+    };


### PR DESCRIPTION
### Issue Number

close: #105 

### 작업 내역

> 구현 내용 및 작업 했던 내역

stomp 기반 웹소켓 코어 로직을 구현합니다.
자세한 내용은 WIKI 웹소켓 페이지를 참고해 주세요.
https://github.com/mash-up-kr/musily-web/wiki/002.-%EC%9B%B9-%EC%86%8C%EC%BC%93-%EC%82%AC%EC%9A%A9-%EB%B0%A9%EB%B2%95

### 변경사항

- Websocket을 useConetext로 전역에서 관리
- 구독 정보 recoil로 상태 관리
- 클라이언트에서 서버에 요청하는 기능을 커스텀훅으로 관리

### PR 특이 사항

> PR을 볼 때 주의깊게 봐야하거나 말하고 싶은 점

- 아직 draft라 이런 식으로 동작하겠구나 예상하는 용도로 봐주시면 감사하겠습니다.
- 에러 핸들링을 어떻게 할지?

### Checklist

> PR 등록 전 확인할 점

- [x] PR 제목은 포맷과 내용 둘 다 알맞게 작성되었는가 (e.g., `feat(user): add login page`)
- [x] assignee가 본인으로 되어있고, label은 PR 주제에 맞게 추가했는가
- [x] description에 PR에 대해 구체적으로 설명했는가
