### PR TITLE
feat(login): 메인 페이지 / 리다이렉션 페이지에서 방 생성한 이력 조회해서 리다이렉션하도록 적용

### DIFF
--- a/pages/index.tsx
+++ b/pages/index.tsx
@@ -1,9 +1,10 @@
-import React, { useState } from "react";
+import React, { useEffect, useState } from "react";
 import type { NextPage } from "next";
 import { useRouter } from "next/router";
 import styled from "@emotion/styled";
 import { TopBar, TopBarIconButton } from "~/components/uis";
 import { withRouteGuard } from "~/hocs";
+import { useRoomsQuery } from "~/hooks/api";
 
 const HomePage: NextPage = withRouteGuard(
   { UNCONNECTED: false, CONNECTED: true },
@@ -12,6 +13,8 @@ const HomePage: NextPage = withRouteGuard(
     const [roomTitle, setRoomTitle] = useState("");
     const router = useRouter();
 
+    const { data, isLoading, isFetching, isError } = useRoomsQuery();
+
     const onSubmit = async (event: React.FormEvent<HTMLFormElement>) => {
       event.preventDefault();
       router.push({
@@ -19,6 +22,22 @@ const HomePage: NextPage = withRouteGuard(
         query: { roomTitle },
       });
     };
+
+    useEffect(() => {
+      if (data) {
+        const { roomId } = data;
+
+        router.replace(`/rooms/${roomId}?isHost=true`);
+      }
+    }, [data]);
+
+    if (isFetching || isLoading || data === undefined) {
+      return <div>Loading, Fetching</div>;
+    }
+
+    if (isError) {
+      router.replace("/rooms/create");
+    }
 
     return (
       <>

--- a/pages/login/redirected/index.tsx
+++ b/pages/login/redirected/index.tsx
@@ -33,9 +33,26 @@ export const useAuthRedirected = () => {
       return data;
     },
     {
-      onSuccess: () => {
+      onSuccess: async ({ token }) => {
         refetchMemberInfo();
-        router.replace("/rooms/create");
+
+        try {
+          const { data } = await axios.get<{ roomId: number }>(
+            `${defaultEndPoint}/api/v1/rooms`,
+            {
+              headers: {
+                Authorization: `Bearer ${token}`,
+              },
+            }
+          );
+          console.log(data);
+          const { roomId } = data;
+
+          router.replace(`/rooms/${roomId}?isHost=true`);
+        } catch (error) {
+          console.log(error);
+          router.replace("/rooms/create");
+        }
       },
     }
   );


### PR DESCRIPTION
### #122

close: #122

### 작업 내역

- 메인 페이지 / 리다이렉션 페이지에서 방 생성한 이력 API 호출하여 찾은 다음 없으면, 생성 페이지로, 있으면 기존 페이지로 이동하도록 수정