### PR TITLE
feat: update mood page

### DIFF
--- a/pages/rooms/[roomId]/setting/index.tsx
+++ b/pages/rooms/[roomId]/setting/index.tsx
@@ -5,37 +5,13 @@ import { useRouter } from "next/router";
 import styled from "@emotion/styled";
 import { AxiosError } from "axios";
 import { BottomButton, TopBar, TopBarIconButton } from "~/components/uis";
-import {
-  useDeleteRoomMutation,
-  usePostLogoutMutation,
-  useRoomQuery,
-} from "~/hooks/api";
-import type { Mood, MoodWithImageName } from "~/types/rooms";
+import { useDeleteRoomMutation, usePostLogoutMutation } from "~/hooks/api";
 
 const tokenKey = process.env.NEXT_PUBLIC_LOCAL_TOKEN_KEY as string;
-
-const moodConstants: MoodWithImageName[] = [
-  {
-    name: "# 조용~ 집중 빡 공부 모드",
-    emojiType: "BOOK",
-    emojiTypeImageName: "book-3d",
-  },
-  {
-    name: "# 쉣댓 부레 엉덩이~! 흔들어버려",
-    emojiType: "MIRROR_BALL",
-    emojiTypeImageName: "mirror-3d",
-  },
-  {
-    name: "# 잔잔한 내적 댄스 유발",
-    emojiType: "HEART",
-    emojiTypeImageName: "heart-3d",
-  },
-];
 
 const RoomSettingPage: NextPage = () => {
   const router = useRouter();
   const [roomId, setRoomId] = useState(0);
-  const { data: roomData } = useRoomQuery(Number(roomId));
 
   useEffect(() => {
     const { roomId } = router.query as { roomId: string };

--- a/pages/rooms/create/index.tsx
+++ b/pages/rooms/create/index.tsx
@@ -23,28 +23,28 @@ const RoomCreatePage: NextPage = withRouteGuard(
         <TopBar leftIconButton={<TopBarIconButton iconName="arrow-left" />}>
           방 만들기
         </TopBar>
-        <StyledContainer>
-          <StyledTitle>나만의 방 이름을 만들어보세요!</StyledTitle>
-          <StyledInput
+        <S.Container>
+          <S.Title>나만의 방 이름을 만들어보세요!</S.Title>
+          <S.Input
             value={value}
             maxLength={12}
             onChange={(e) => setValue(e.target.value)}
             placeholder="방 이름"
           />
-          <StyledNoticeTextWrapper gap={4}>
+          <S.NoticeTextWrapper gap={4}>
             <Image
               src={`/images/info-circle-mono.svg`}
               alt="icon"
               width={14}
               height={14}
             />
-            <StyledNoticeText>
+            <S.NoticeText>
               최대 빈칸 포함 12자까지 입력 가능해요.
               <br />
               이후에 언제든지 변경할 수 있습니다:)
-            </StyledNoticeText>
-          </StyledNoticeTextWrapper>
-        </StyledContainer>
+            </S.NoticeText>
+          </S.NoticeTextWrapper>
+        </S.Container>
         <Link
           href={{ pathname: "/rooms/create/mood", query: { roomName: value } }}
         >
@@ -57,43 +57,41 @@ const RoomCreatePage: NextPage = withRouteGuard(
   }
 );
 
-const StyledContainer = styled.div`
-  display: flex;
-  flex-direction: column;
-  justify-content: center;
-  align-items: center;
-  position: relative;
-  height: calc(100% - 104px);
-  padding: 20px 0;
-`;
-
-const StyledTitle = styled.h3`
-  font-size: 18px;
-  font-weight: 500;
-`;
-
-const StyledInput = styled.input`
-  width: 100%;
-  margin-top: 32px;
-  text-align: center;
-  font-size: 36px;
-  color: white;
-  border: none;
-  background: none;
-  :focus {
-    outline: none;
-  }
-`;
-
-const StyledNoticeTextWrapper = styled(Spacer)`
-  position: absolute;
-  bottom: 32px;
-  align-items: flex-start;
-`;
-
-const StyledNoticeText = styled.span`
-  font-size: 13px;
-  color: #8e96a0;
-`;
+const S = {
+  Container: styled.div`
+    display: flex;
+    flex-direction: column;
+    justify-content: center;
+    align-items: center;
+    position: relative;
+    height: calc(100% - 104px);
+    padding: 20px 0;
+  `,
+  Title: styled.h3`
+    font-size: 18px;
+    font-weight: 500;
+  `,
+  Input: styled.input`
+    width: 100%;
+    margin-top: 32px;
+    text-align: center;
+    font-size: 36px;
+    color: white;
+    border: none;
+    background: none;
+    :focus {
+      outline: none;
+    }
+  `,
+  NoticeTextWrapper: styled(Spacer)`
+    position: absolute;
+    bottom: 32px;
+    align-items: flex-start;
+  `,
+  NoticeText: styled.span`
+    font-size: 13px;
+    color: #8e96a0;
+  `,
+};
 
 export default RoomCreatePage;

--- a/pages/rooms/create/index.tsx
+++ b/pages/rooms/create/index.tsx
@@ -1,7 +1,7 @@
 import React, { useState } from "react";
 import type { NextPage } from "next";
 import Image from "next/image";
-import Link from "next/link";
+import { useRouter } from "next/router";
 import styled from "@emotion/styled";
 import {
   BottomButton,
@@ -17,6 +17,13 @@ const RoomCreatePage: NextPage = withRouteGuard(
   "/login",
   () => {
     const [value, setValue] = useState("");
+    const router = useRouter();
+    const handleClick = () => {
+      router.push({
+        pathname: "/rooms/create/mood",
+        query: { roomName: value },
+      });
+    };
 
     return (
       <Layout screenColor="linear-gradient(#000, 90%, #01356E)">
@@ -45,13 +52,11 @@ const RoomCreatePage: NextPage = withRouteGuard(
             </S.NoticeText>
           </S.NoticeTextWrapper>
         </S.Container>
-        <Link
-          href={{ pathname: "/rooms/create/mood", query: { roomName: value } }}
-        >
-          <a>
-            <BottomButton label="다음" disabled={value.length === 0} />
-          </a>
-        </Link>
+        <BottomButton
+          label="다음"
+          disabled={value.length === 0}
+          onClick={handleClick}
+        />
       </Layout>
     );
   }

--- a/pages/rooms/create/mood/index.tsx
+++ b/pages/rooms/create/mood/index.tsx
@@ -76,8 +76,8 @@ const RoomCreateMoodPage: NextPage = () => {
       <TopBar leftIconButton={<TopBarIconButton iconName="arrow-left" />}>
         방 만들기
       </TopBar>
-      <StyledContainer>
-        <StyledTitle>
+      <S.Container>
+        <S.Title>
           <Image
             src={`/images/ticket.svg`}
             alt="icon"
@@ -85,11 +85,11 @@ const RoomCreateMoodPage: NextPage = () => {
             height={38}
           />
           &nbsp; 의&nbsp;무드는?
-        </StyledTitle>
-        <StyledSubTitle>무드에 맞춘 이모지를 제공해드려요!</StyledSubTitle>
-        <StyledButtonGroup type="vertical" gap={15}>
+        </S.Title>
+        <S.SubTitle>무드에 맞춘 이모지를 제공해드려요!</S.SubTitle>
+        <S.ButtonGroup type="vertical" gap={15}>
           {moodConstants.map((moodConstant) => (
-            <StyledButton
+            <S.Button
               key={moodConstant.name}
               onClick={() => {
                 setIsEdit(false);
@@ -97,16 +97,16 @@ const RoomCreateMoodPage: NextPage = () => {
               }}
               isActive={mood.name === moodConstant.name}
             >
-              <StyledButtonText>{moodConstant.name}</StyledButtonText>
+              <S.ButtonText>{moodConstant.name}</S.ButtonText>
               <Image
                 src={`/images/${moodConstant.emojiTypeImageName}.svg`}
                 alt="icon"
                 width={56}
                 height={58}
               />
-            </StyledButton>
+            </S.Button>
           ))}
-          <StyledButton
+          <S.Button
             key={mood.emojiType}
             onClick={() => {
               if (!isEdit) {
@@ -123,8 +123,8 @@ const RoomCreateMoodPage: NextPage = () => {
             }}
             isActive={isEdit}
           >
-            <StyledMoodPrefixText isActive={isEdit}>#</StyledMoodPrefixText>
-            <StyledMoodInputText
+            <S.MoodPrefixText isActive={isEdit}>#</S.MoodPrefixText>
+            <S.MoodInputText
               placeholder="직접 입력"
               value={selectedMood.name}
               onChange={(e: React.ChangeEvent<HTMLInputElement>) => {
@@ -134,10 +134,10 @@ const RoomCreateMoodPage: NextPage = () => {
                 });
               }}
               isActive={isEdit}
-            ></StyledMoodInputText>
-            <StyledMoodGroupContainer>
+            ></S.MoodInputText>
+            <S.MoodGroupContainer>
               {moodConstants.map((moodConstant) => (
-                <StyledMoodSelectedContainer
+                <S.MoodSelectedContainer
                   key={moodConstant.name}
                   isSelectedMood={
                     moodConstant.emojiType === selectedMood.emojiType
@@ -157,106 +157,98 @@ const RoomCreateMoodPage: NextPage = () => {
                       }
                     }}
                   />
-                </StyledMoodSelectedContainer>
+                </S.MoodSelectedContainer>
               ))}
-            </StyledMoodGroupContainer>
-          </StyledButton>
-        </StyledButtonGroup>
-      </StyledContainer>
+            </S.MoodGroupContainer>
+          </S.Button>
+        </S.ButtonGroup>
+      </S.Container>
       <BottomButton label="방 만들기" onClick={onClickCreateRoom} />
     </>
   );
 };
 
-const StyledContainer = styled.div`
-  display: flex;
-  flex-direction: column;
-  justify-content: center;
-  align-items: center;
-  position: relative;
-  height: calc(100% - 104px);
-  padding: 20px 16px;
-`;
-
-const StyledTitle = styled.h3`
-  display: flex;
-  align-items: center;
-  font-size: 18px;
-`;
-
-const StyledSubTitle = styled.p`
-  margin-top: 17px;
-  font-size: 16px;
-  color: #8b95a1;
-`;
-
-const StyledButtonGroup = styled(Spacer)`
-  width: 100%;
-  margin-top: 35px;
-`;
-
-const StyledButton = styled.button<{ isActive: boolean }>`
-  display: flex;
-  justify-content: space-between;
-  align-items: center;
-  padding: 0px 22px;
-  border: none;
-  background: ${(p) => (p.isActive ? "white" : "rgba(64, 73, 83, 0.85)")};
-  color: ${(p) => (p.isActive ? "#007AFF" : "white")};
-  border-radius: 20px;
-`;
-
-const StyledButtonText = styled.p`
-  font-size: 16px;
-  font-weight: 700;
-`;
-
-const StyledMoodPrefixText = styled.span<{ isActive: boolean }>`
-  color: ${(p) => (p.isActive ? "#007AFF" : "white")};
-  font-size: 16px;
-  font-weight: 700;
-  line-height: 19px;
-  background-color: transparent;
-`;
-
-const StyledMoodInputText = styled.input<{ isActive: boolean }>`
-  color: ${(p) => (p.isActive ? "#007AFF" : "white")};
-  font-size: 16px;
-  font-weight: 700;
-  line-height: 19px;
-  background-color: transparent;
-  border: none;
-  height: 100%;
-
-  &::placeholder {
+const S = {
+  Container: styled.div`
+    display: flex;
+    flex-direction: column;
+    justify-content: center;
+    align-items: center;
+    position: relative;
+    height: calc(100% - 104px);
+    padding: 20px 16px;
+  `,
+  Title: styled.h3`
+    display: flex;
+    align-items: center;
+    font-size: 18px;
+  `,
+  SubTitle: styled.p`
+    margin-top: 17px;
+    font-size: 16px;
+    color: #8b95a1;
+  `,
+  ButtonGroup: styled(Spacer)`
+    width: 100%;
+    margin-top: 35px;
+  `,
+  Button: styled.button<{ isActive: boolean }>`
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
+    padding: 0px 22px;
+    border: none;
+    background: ${(p) => (p.isActive ? "white" : "rgba(64, 73, 83, 0.85)")};
+    color: ${(p) => (p.isActive ? "#007AFF" : "white")};
+    border-radius: 20px;
+  `,
+  ButtonText: styled.p`
+    font-size: 16px;
+    font-weight: 700;
+  `,
+  MoodPrefixText: styled.span<{ isActive: boolean }>`
     color: ${(p) => (p.isActive ? "#007AFF" : "white")};
     font-size: 16px;
     font-weight: 700;
     line-height: 19px;
-  }
-`;
-
-const StyledMoodGroupContainer = styled.div`
-  height: 80%;
-  display: flex;
-  flex-direction: row;
-  justify-content: center;
-  align-items: center;
-  position: relative;
-  background-color: #f0f0f0;
-  border-radius: 16px;
-`;
-
-const StyledMoodSelectedContainer = styled.div<{ isSelectedMood: boolean }>`
-  height: 100%;
-  width: 100%;
-  border-radius: 16px;
-  background-color: ${(p) => (p.isSelectedMood ? "#e2e2e2" : "transparent")};
-  display: flex;
-  flex-direction: row;
-  justify-content: center;
-  align-items: center;
-  position: relative;
-`;
+    background-color: transparent;
+  `,
+  MoodInputText: styled.input<{ isActive: boolean }>`
+    color: ${(p) => (p.isActive ? "#007AFF" : "white")};
+    font-size: 16px;
+    font-weight: 700;
+    line-height: 19px;
+    background-color: transparent;
+    border: none;
+    height: 100%;
+    &::placeholder {
+      color: ${(p) => (p.isActive ? "#007AFF" : "white")};
+      font-size: 16px;
+      font-weight: 700;
+      line-height: 19px;
+    }
+  `,
+  MoodGroupContainer: styled.div`
+    height: 80%;
+    display: flex;
+    flex-direction: row;
+    justify-content: center;
+    align-items: center;
+    position: relative;
+    background-color: #f0f0f0;
+    border-radius: 16px;
+  `,
+  MoodSelectedContainer: styled.div<{ isSelectedMood: boolean }>`
+    height: 100%;
+    width: 100%;
+    border-radius: 16px;
+    background-color: ${(p) => (p.isSelectedMood ? "#e2e2e2" : "transparent")};
+    display: flex;
+    flex-direction: row;
+    justify-content: center;
+    align-items: center;
+    position: relative;
+  `,
+};
 
 export default RoomCreateMoodPage;

--- a/types/rooms/moods/index.ts
+++ b/types/rooms/moods/index.ts
@@ -4,7 +4,3 @@ export interface Mood {
   name: string;
   emojiType: EmojiType;
 }
-
-export interface MoodWithImageName extends Mood {
-  emojiTypeImageName: string;
-}


### PR DESCRIPTION
### Issue Number

close: #131 

### 작업 내역

무드 페이지 화면 구현을 마무리합니다.

- 방 제목의 티켓 디자인 구현
- 직접 입력 버튼을 클릭했을 때 커스텀 무드 설정 버튼이 활성화되게끔 수정
- 기타 자잘한 UI 및 로직 리팩토링 및 수정

https://user-images.githubusercontent.com/38487811/186735297-0cae13b6-11ea-4136-a15e-9003cb0c9562.mov

### NOTE

현재 서버에서 무드 이름을 저장하고 있지 않아 관련해서 추가 요청을 보낼 예정입니다. 따라서 무드 이름을 저장할 수 있게 되면 추가로 코드 변경이 일어날 수 있다는 점 확인 부탁드립니다.


### Checklist

> PR 등록 전 확인할 점

- [x] PR 제목은 포맷과 내용 둘 다 알맞게 작성되었는가 (e.g., `feat(user): add login page`)
- [x] assignee가 본인으로 되어있고, label은 PR 주제에 맞게 추가했는가
- [x] description에 PR에 대해 구체적으로 설명했는가
